### PR TITLE
Updates README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This repository contains snap installed on several linux operating system.
 * Alpine 3.4 ([alpine/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/alpine/Dockerfile))
 * CentOS 6 ([centos6/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/centos6/Dockerfile))
 * CentOS 7 ([centos7/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/centos7/Dockerfile))
-* Ubuntu 12.04 trusty ([trusty/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/trusty/Dockerfile))
-* Ubuntu 14.04 precise ([precise/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/precise/Dockerfile))
+* Ubuntu 12.04 precise ([trusty/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/precise/Dockerfile))
+* Ubuntu 14.04 trusty ([precise/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/trusty/Dockerfile))
 * Ubuntu 16.04 xenial ([precise/Dockerfile](https://github.com/intelsdi-x/snap-docker/blob/master/xenial/Dockerfile))
 
 Additional [image layer info](https://microbadger.com/#/images/intelsdi/snap)


### PR DESCRIPTION
The dockerfile that Ubuntu 12.04 precise pointed to was mixed up with 14.04 trusty.