### PR TITLE
Rename $SNAP_URL

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,7 +7,7 @@ ARG SNAP_VERSION=latest
 ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
-ENV SNAP_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Alpine 3.4" \
@@ -18,8 +18,8 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
 COPY init_snap /usr/local/bin/init_snap
 COPY snapd.conf /etc/snap/snapd.conf
 

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -7,7 +7,7 @@ ARG SNAP_VERSION=latest
 ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
-ENV SNAP_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Centos 6" \
@@ -18,8 +18,8 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
 COPY init_snap /usr/local/bin/init_snap
 COPY snapd.conf /etc/snap/snapd.conf
 

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -7,7 +7,7 @@ ARG SNAP_VERSION=latest
 ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
-ENV SNAP_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Centos 7" \
@@ -18,8 +18,8 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
 COPY init_snap /usr/local/bin/init_snap
 COPY snapd.conf /etc/snap/snapd.conf
 

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -7,7 +7,7 @@ ARG SNAP_VERSION=latest
 ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
-ENV SNAP_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Ubuntu 12.04" \
@@ -18,8 +18,8 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
 COPY init_snap /usr/local/bin/init_snap
 COPY snapd.conf /etc/snap/snapd.conf
 

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -45,7 +45,7 @@ BUILDS.each do |os|
       describe docker_build("#{os}/.") do
         include_examples "metadata"
 
-        it { should have_env "SNAP_URL" }
+        it { should have_env "CI_URL" }
         it { should have_label( "io.snap-telemetry.snap.version" => "latest" ) }
 
         describe docker_run(described_image) do

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -7,7 +7,7 @@ ARG SNAP_VERSION=latest
 ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
-ENV SNAP_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Ubuntu 14.04" \
@@ -18,8 +18,8 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
 COPY init_snap /usr/local/bin/init_snap
 COPY snapd.conf /etc/snap/snapd.conf
 

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -7,7 +7,7 @@ ARG SNAP_VERSION=latest
 ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
-ENV SNAP_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Ubuntu 16.04" \
@@ -18,8 +18,8 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${SNAP_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
 COPY init_snap /usr/local/bin/init_snap
 COPY snapd.conf /etc/snap/snapd.conf
 


### PR DESCRIPTION
It was causing conflict with <del>snapctl</del> snaptel that use `$SNAP_URL` to point to the Snap API.