### PR TITLE
(SDI-2201) migrate to new snaptel/snapteld binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use a specific version of snap, please use `<version>_<os>` tag:
 ```
 $ docker run -e intelsdi/snap:0.15.0_alpine
 time="2016-08-30T17:52:04Z" level=info msg="setting log level to: debug"
-time="2016-08-30T17:52:04Z" level=info msg="Starting snapd (version: v0.15.0-beta)"
+time="2016-08-30T17:52:04Z" level=info msg="Starting snapteld (version: v0.15.0-beta)"
 ```
 
 The following tags are test containers. On startup, the operating system will use curl to fetch the latest snap build (most current commit in the snap repo):
@@ -56,18 +56,18 @@ To specify a particular release, use SNAP_VERSION environment variable:
 ```
 $ docker run -e SNAP_VERSION=0.15.0 intelsdi/snap:alpine_test
 time="2016-08-30T17:52:04Z" level=info msg="setting log level to: debug"
-time="2016-08-30T17:52:04Z" level=info msg="Starting snapd (version: v0.15.0-beta)"
+time="2016-08-30T17:52:04Z" level=info msg="Starting snapteld (version: v0.15.0-beta)"
 ...
 ```
 
 ```
 $ docker run -e SNAP_VERSION=906d19b646837393f9893870cc2929e791b1f3fb intelsdi/snap:alpine_test
 time="2016-08-30T17:58:10Z" level=info msg="setting log level to: debug"
-time="2016-08-30T17:58:10Z" level=info msg="Starting snapd (version: test-906d19b)"
+time="2016-08-30T17:58:10Z" level=info msg="Starting snapteld (version: test-906d19b)"
 ...
 ```
 
-See snapd man page for additional information on environment variables such as SNAP_TRUST_LEVEL, SNAP_LOG_LEVEL.
+See snapteld man page for additional information on environment variables such as SNAP_TRUST_LEVEL, SNAP_LOG_LEVEL.
 
 ## Build Docker Containers
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,9 +18,9 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld  /opt/snap/sbin/snapteld
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel  /opt/snap/bin/snaptel
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/alpine/snapd.conf
+++ b/alpine/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/alpine/snapteld.conf
+++ b/alpine/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/alpine_test/Dockerfile
+++ b/alpine_test/Dockerfile
@@ -23,6 +23,6 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/alpine_test/snapd.conf
+++ b/alpine_test/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/alpine_test/snapteld.conf
+++ b/alpine_test/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -18,9 +18,9 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld  /opt/snap/sbin/snapteld
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel  /opt/snap/bin/snaptel
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/centos6/snapd.conf
+++ b/centos6/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/centos6/snapteld.conf
+++ b/centos6/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/centos6_test/Dockerfile
+++ b/centos6_test/Dockerfile
@@ -20,6 +20,6 @@ ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/bin/
 RUN chmod 755 /usr/bin/jq
 
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/centos6_test/snapd.conf
+++ b/centos6_test/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/centos6_test/snapteld.conf
+++ b/centos6_test/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -18,9 +18,9 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld  /opt/snap/sbin/snapteld
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel  /opt/snap/bin/snaptel
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/centos7/snapd.conf
+++ b/centos7/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/centos7/snapteld.conf
+++ b/centos7/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/centos7_test/Dockerfile
+++ b/centos7_test/Dockerfile
@@ -20,6 +20,6 @@ ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/bin/
 RUN chmod 755 /usr/bin/jq
 
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/centos7_test/snapd.conf
+++ b/centos7_test/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/centos7_test/snapteld.conf
+++ b/centos7_test/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/init_snap
+++ b/init_snap
@@ -4,20 +4,22 @@ set -e
 set -u
 
 SNAP_VERSION=${SNAP_VERSION:-latest}
-
+CI_URL=${CI_URL:-https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io}
+mkdir -p /usr/local/sbin
 mkdir -p /opt/snap/bin
 mkdir -p /opt/snap/sbin
 mkdir -p /opt/snap/plugins
 mkdir -p /var/log/snap
 mkdir -p /etc/snap
 
-[ -f /opt/snap/bin/snapd ] || curl -sfL "https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io/snap/${SNAP_VERSION}/linux/x86_64/snapd" -o /opt/snap/bin/snapd
-[ -f /opt/snap/bin/snapctl ] || curl -sfL "https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io/snap/${SNAP_VERSION}/linux/x86_64/snapctl" -o /opt/snap/bin/snapctl
-chmod 755 /opt/snap/bin/snapd
-chmod 755 /opt/snap/bin/snapctl
-[ -f /usr/local/bin/snapd ] || ln -s /opt/snap/bin/snapd /usr/local/bin/snapd
-[ -f /usr/local/bin/snapctl ] || ln -s /opt/snap/bin/snapctl /usr/local/bin/snapctl
-[ -f /opt/snap/sbin/snapteld ] || ln -s /opt/snap/bin/snapd /opt/snap/sbin/snapteld
-[ -f /opt/snap/bin/snaptel ] || ln -s /opt/snap/bin/snapctl /opt/snap/bin/snaptel
-[ -f /usr/sbin/snapteld ] || ln -s /opt/snap/bin/snapd /usr/sbin/snapteld
-[ -f /usr/bin/snaptel ] || ln -s /opt/snap/bin/snapctl /usr/bin/snaptel
+[ -f /opt/snap/sbin/snapteld ] || (curl -sfL "${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld" -o /opt/snap/sbin/snapteld || curl -sfL "${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd" -o /opt/snap/sbin/snapteld)
+[ -f /opt/snap/bin/snaptel ] || (curl -sfL "${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel" -o /opt/snap/bin/snaptel || curl -sfL "${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl" -o /opt/snap/bin/snaptel)
+chmod 755 /opt/snap/sbin/snapteld
+chmod 755 /opt/snap/bin/snaptel
+[ -f /usr/local/sbin/snapteld ] || ln -s /opt/snap/sbin/snapteld /usr/local/sbin/snapteld
+[ -f /usr/local/bin/snaptel ] || ln -s /opt/snap/bin/snaptel /usr/local/bin/snaptel
+
+# This can be removed after test have been migrated to the new binaries
+[ -f /usr/local/sbin/snapd ] || ln -s /opt/snap/sbin/snapteld /usr/local/sbin/snapd
+[ -f /usr/local/bin/snapctl ] || ln -s /opt/snap/bin/snaptel /usr/local/bin/snapctl
+[ -f /etc/snap/snapd.conf ] || ln -s /etc/snap/snapteld.conf /etc/snap/snapd.conf

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -18,9 +18,9 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld  /opt/snap/sbin/snapteld
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel  /opt/snap/bin/snaptel
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/precise/snapd.conf
+++ b/precise/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/precise/snapteld.conf
+++ b/precise/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/precise_test/Dockerfile
+++ b/precise_test/Dockerfile
@@ -24,6 +24,6 @@ RUN apt-get update && apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/precise_test/snapd.conf
+++ b/precise_test/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/precise_test/snapteld.conf
+++ b/precise_test/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/snapteld.conf
+++ b/snapteld.conf
@@ -5,17 +5,17 @@
 # log_level: 3
 
 # log_path sets the path for logs for the snap daemon. By
-# default snapd prints all logs to stdout. Any provided
-# path will send snapd logs to a file called snapd.log in
+# default snapteld prints all logs to stdout. Any provided
+# path will send snapteld logs to a file called snapteld.log in
 # the provided directory.
 log_path: /var/log/snap
 
 # Gomaxprocs sets the number of cores to use on the system
-# for snapd to use. Default for gomaxprocs is 1
+# for snapteld to use. Default for gomaxprocs is 1
 # gomaxprocs: 1
 
 # Control sections for configuration settings for the plugin
-# control module of snapd.
+# control module of snapteld.
 control:
   # auto_discover_path sets a directory to auto load plugins on the start
   # of the snap daemon
@@ -33,9 +33,9 @@ control:
   # plugins. This can be a comma separated list of directories
   # keyring_paths: /etc/snap/keyrings
 
-  # plugin_trust_level sets the plugin trust level for snapd. The default state
+  # plugin_trust_level sets the plugin trust level for snapteld. The default state
   # for plugin trust level is enabled (1). When enabled, only signed plugins that can
-  # be verified will be loaded into snapd. Signatures are verifed from
+  # be verified will be loaded into snapteld. Signatures are verifed from
   # keyring files specided in keyring_path. Plugin trust can be disabled (0) which
   # will allow loading of all plugins whether signed or not. The warning state allows
   # for loading of signed and unsigned plugins. Warning messages will be displayed if
@@ -50,17 +50,17 @@ control:
 # scheduler configuration settings contains all settings for scheduler
 # module
 # scheduler:
-  # work_manager_queue_size sets the size of the worker queue inside snapd scheduler.
+  # work_manager_queue_size sets the size of the worker queue inside snapteld scheduler.
   # Default value is 25.
   # work_manager_queue_size: 25
 
-  # work_manager_pool_size sets the size of the worker pool inside snapd scheduler.
+  # work_manager_pool_size sets the size of the worker pool inside snapteld scheduler.
   # Default value is 4.
   # work_manager_pool_size: 4
 
 # rest sections contains all the configuration items for the REST API server.
 # restapi:
-  # enable controls enabling or disabling the REST API for snapd. Default value is enabled.
+  # enable controls enabling or disabling the REST API for snapteld. Default value is enabled.
   # enable: true
 
   # https enables HTTPS for the REST API. If no default certificate and key are provided, then
@@ -87,7 +87,7 @@ control:
 
 # tribe section contains all configuration items for the tribe module
 # tribe:
-  # enable controls enabling tribe for the snapd instance. Default value is false.
+  # enable controls enabling tribe for the snapteld instance. Default value is false.
   # enable: false
 
   # bind_addr sets the IP address for tribe to bind.
@@ -96,9 +96,9 @@ control:
   # bind_port sets the port for tribe to listen on. Default value is 6000
   # bind_port: 6000
 
-  # name sets the name to use for this snapd instance in the tribe
+  # name sets the name to use for this snapteld instance in the tribe
   # membership. Default value defaults to local hostname of the system.
   # name: localhost
 
-  # seed sets the snapd instance to use as the seed for tribe communications
+  # seed sets the snapteld instance to use as the seed for tribe communications
   # seed: localhost:6000

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -18,9 +18,9 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld  /opt/snap/sbin/snapteld
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel  /opt/snap/bin/snaptel
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/trusty/snapd.conf
+++ b/trusty/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/trusty/snapteld.conf
+++ b/trusty/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/trusty_test/Dockerfile
+++ b/trusty_test/Dockerfile
@@ -21,6 +21,6 @@ RUN apt-get update && apt-get install -y curl jq && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/trusty_test/snapd.conf
+++ b/trusty_test/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/trusty_test/snapteld.conf
+++ b/trusty_test/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -18,9 +18,9 @@ LABEL vendor="Intelsdi-X" \
 
 EXPOSE 8181
 
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapd  /opt/snap/bin/snapd
-ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapctl  /opt/snap/bin/snapctl
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snapteld  /opt/snap/sbin/snapteld
+ADD ${CI_URL}/snap/${SNAP_VERSION}/linux/x86_64/snaptel  /opt/snap/bin/snaptel
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/xenial/snapd.conf
+++ b/xenial/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/xenial/snapteld.conf
+++ b/xenial/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf

--- a/xenial_test/Dockerfile
+++ b/xenial_test/Dockerfile
@@ -22,6 +22,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY init_snap /usr/local/bin/init_snap
-COPY snapd.conf /etc/snap/snapd.conf
+COPY snapteld.conf /etc/snap/snapteld.conf
 
-CMD /usr/local/bin/init_snap && /opt/snap/bin/snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''
+CMD /usr/local/bin/init_snap && /opt/snap/sbin/snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o ''

--- a/xenial_test/snapd.conf
+++ b/xenial_test/snapd.conf
@@ -1,1 +1,0 @@
-../snapd.conf

--- a/xenial_test/snapteld.conf
+++ b/xenial_test/snapteld.conf
@@ -1,0 +1,1 @@
+../snapteld.conf


### PR DESCRIPTION
Fixes #16 

#17 needs to be merge first. And Snap 0.19 needs to be released.

Changes:
- Binaries are renamed to snaptel/snapteld.
- Symlink snaptel/snapteld ==> snapctl/snapd for test containers only.
- Production ready container can't pull version of Snap < 0.19 