### PR TITLE
Add $SNAP_URL environment variable

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,6 +8,7 @@ ENV SNAP_VERSION=${SNAP_VERSION}
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
 ENV CI_URL=https://s3-us-west-2.amazonaws.com/snap.ci.snap-telemetry.io
+ENV SNAP_URL="http://127.0.0.1:8181"
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Alpine 3.4" \

--- a/alpine_test/Dockerfile
+++ b/alpine_test/Dockerfile
@@ -6,6 +6,7 @@ ARG BUILD_DATE
 ENV SNAP_VERSION="latest_build"
 ENV SNAP_TRUST_LEVEL=0
 ENV SNAP_LOG_LEVEL=1
+ENV SNAP_URL="http://127.0.0.1:8181"
 
 LABEL vendor="Intelsdi-X" \
       name="Snap Alpine 3.4" \


### PR DESCRIPTION
Fixes #20 

Alpine takes time to resolve localhost, this makes `snaptel` answer faster.